### PR TITLE
Implement mcp-hmr library and demo

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -1,0 +1,10 @@
+# MCP Demo (with mcp-hmr)
+
+Run with hot reload:
+
+```sh
+mcp-hmr server:serve
+```
+
+Then edit `logic.py` and see the output change on the next input.
+

--- a/examples/mcp/logic.py
+++ b/examples/mcp/logic.py
@@ -4,4 +4,3 @@ from datetime import datetime
 def greet(name: str) -> str:
     # Edit this function while the server is running to see HMR in action
     return f"Hello, {name}! The time is {datetime.now():%H:%M:%S}"
-

--- a/examples/mcp/logic.py
+++ b/examples/mcp/logic.py
@@ -1,0 +1,7 @@
+from datetime import datetime
+
+
+def greet(name: str) -> str:
+    # Edit this function while the server is running to see HMR in action
+    return f"Hello, {name}! The time is {datetime.now():%H:%M:%S}"
+

--- a/examples/mcp/pyproject.toml
+++ b/examples/mcp/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "mcp-demo"
+version = "0"
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+

--- a/examples/mcp/server.py
+++ b/examples/mcp/server.py
@@ -1,0 +1,22 @@
+import asyncio
+import sys
+from typing import NoReturn
+
+from logic import greet
+
+
+async def _readline() -> str:
+    return await asyncio.to_thread(sys.stdin.readline)
+
+
+async def serve() -> NoReturn:  # entry for `mcp-hmr`
+    print("MCP demo server started. Type a name and press Enter (Ctrl+C to stop)", flush=True)
+    try:
+        while True:
+            line = (await _readline()).strip()
+            if not line:
+                continue
+            print(f"Response: {greet(line)}", flush=True)
+    except asyncio.CancelledError:  # graceful cancellation on reload
+        pass
+

--- a/examples/mcp/server.py
+++ b/examples/mcp/server.py
@@ -1,6 +1,5 @@
 import asyncio
 import sys
-from typing import NoReturn
 
 from logic import greet
 
@@ -9,7 +8,7 @@ async def _readline() -> str:
     return await asyncio.to_thread(sys.stdin.readline)
 
 
-async def serve() -> NoReturn:  # entry for `mcp-hmr`
+async def serve() -> None:  # entry for `mcp-hmr`
     print("MCP demo server started. Type a name and press Enter (Ctrl+C to stop)", flush=True)
     try:
         while True:

--- a/examples/mcp/server.py
+++ b/examples/mcp/server.py
@@ -19,4 +19,3 @@ async def serve() -> NoReturn:  # entry for `mcp-hmr`
             print(f"Response: {greet(line)}", flush=True)
     except asyncio.CancelledError:  # graceful cancellation on reload
         pass
-

--- a/packages/mcp-hmr/README.md
+++ b/packages/mcp-hmr/README.md
@@ -1,0 +1,32 @@
+# mcp-hmr
+
+Hot Module Reloading runner for MCP servers (or any Python async entrypoint).
+
+- Uses `hmr` to reload only changed modules and their dependents
+- Keeps the main process alive; restarts your async server task inside
+- Simple CLI: `mcp-hmr path.to.module:serve`
+
+## Install
+
+```sh
+pip install mcp-hmr
+```
+
+## Usage
+
+From the directory where your module is located:
+
+```sh
+mcp-hmr server:serve
+```
+
+The callable after the colon must be a function or coroutine function returning an awaitable that runs your server. On reload, `mcp-hmr` cancels the currently running task, reloads affected modules, and invokes the callable again.
+
+### Options
+
+- `reload-include` and `reload-exclude`: lists of paths similar to `uvicorn-hmr` (no glob patterns). Defaults: include current dir; exclude current virtualenv.
+- `--clear`: clear terminal on restart.
+
+## Demo
+
+See `examples/mcp` in this repo for a minimal MCP-like stdio server that echoes a computed string; change code and see live reload.

--- a/packages/mcp-hmr/__init__.py
+++ b/packages/mcp-hmr/__init__.py
@@ -1,4 +1,3 @@
 from .mcp_hmr import app
 
 __all__ = ["app"]
-

--- a/packages/mcp-hmr/__init__.py
+++ b/packages/mcp-hmr/__init__.py
@@ -1,0 +1,4 @@
+from .mcp_hmr import app
+
+__all__ = ["app"]
+

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -5,11 +5,12 @@ import inspect
 import sys
 from atexit import register
 from functools import cached_property
+from collections.abc import Awaitable, Callable
 from importlib.machinery import ModuleSpec
 from logging import getLogger
 from pathlib import Path
 from threading import Event, Thread
-from typing import TYPE_CHECKING, Annotated, Awaitable, Callable, override
+from typing import Annotated, override
 
 from typer import Argument, Option, Typer, secho
 
@@ -55,12 +56,11 @@ def main(
             fg="red",
         )
 
-    from reactivity.hmr.core import ReactiveModule, ReactiveModuleLoader, SyncReloader, __version__, is_relative_to_any
+    from reactivity.hmr.core import ReactiveModule, ReactiveModuleLoader, SyncReloader, __version__
     from reactivity.hmr.utils import load
     from watchfiles import Change
 
-    if TYPE_CHECKING:
-        ServerCallable = Callable[[], Awaitable[object] | object]
+    ServerCallable = Callable[[], Awaitable[object] | object]
 
     cwd = str(Path.cwd())
     if cwd not in sys.path:
@@ -109,10 +109,10 @@ def main(
         try:
             fut = asyncio.run_coroutine_threadsafe(_cancel(), loop)
             fut.result(timeout=2.0)
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
 
-    def start_server(fn: "ServerCallable"):
+    def start_server(fn: ServerCallable):
         nonlocal current_task
 
         def _start() -> asyncio.Future:
@@ -128,7 +128,7 @@ def main(
                         raise TypeError("Entry callable must be or return an awaitable")
                 else:
                     raise TypeError("Entry callable must be or return an awaitable")
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 logger.error("Failed to start server: %s", exc)
                 raise
             # Accept any awaitable (not just coroutine) using ensure_future
@@ -148,7 +148,7 @@ def main(
             loop.call_soon_threadsafe(_cb)
             if not ready.wait(timeout=1.0):
                 raise TimeoutError("Timeout scheduling server task")
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.error("Failed to schedule server: %s", exc)
 
     class Reloader(SyncReloader):

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -4,8 +4,8 @@ import asyncio
 import inspect
 import sys
 from atexit import register
-from functools import cached_property
 from collections.abc import Awaitable, Callable
+from functools import cached_property
 from importlib.machinery import ModuleSpec
 from logging import getLogger
 from pathlib import Path

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -213,4 +213,3 @@ def _display_path(path: str | Path):
 
 if __name__ == "__main__":
     app()
-

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+from atexit import register
+from functools import cached_property
+from importlib.machinery import ModuleSpec
+from logging import getLogger
+from pathlib import Path
+from threading import Event, Thread
+from typing import TYPE_CHECKING, Annotated, Awaitable, Callable, override
+
+from typer import Argument, Option, Typer, secho
+
+
+app = Typer(help="Hot Module Reloading for MCP-like async servers", add_completion=False, pretty_exceptions_show_locals=False)
+
+
+@app.command(no_args_is_help=True)
+def main(
+    slug: Annotated[str, Argument()] = "server:serve",
+    reload_include: list[str] = [str(Path.cwd())],  # noqa: B006, B008
+    reload_exclude: list[str] = [".venv"],  # noqa: B006
+    clear: Annotated[bool, Option("--clear", help="Clear the terminal before restarting the server")] = False,  # noqa: FBT002
+):
+    if ":" not in slug:
+        secho("Invalid slug: ", fg="red", nl=False)
+        secho(slug, fg="yellow")
+        raise SystemExit(1)
+
+    module, attr = slug.split(":")
+
+    fragment = module.replace(".", "/")
+
+    is_package = False
+    for path in ("", *sys.path):
+        if (file := Path(path, f"{fragment}.py")).is_file():
+            is_package = False
+            break
+        if (file := Path(path, fragment, "__init__.py")).is_file():
+            is_package = True
+            break
+    else:
+        secho("Module", fg="red", nl=False)
+        secho(f" {module} ", fg="yellow", nl=False)
+        secho("not found.", fg="red")
+        raise SystemExit(1)
+
+    file = file.resolve()
+
+    if module in sys.modules:
+        return secho(
+            f"It seems you've already imported `{module}` as a normal module. You should call `reactivity.hmr.core.patch_meta_path()` before it.",
+            fg="red",
+        )
+
+    from reactivity.hmr.core import ReactiveModule, ReactiveModuleLoader, SyncReloader, __version__, is_relative_to_any
+    from reactivity.hmr.utils import load
+    from watchfiles import Change
+
+    if TYPE_CHECKING:
+        ServerCallable = Callable[[], Awaitable[object] | object]
+
+    cwd = str(Path.cwd())
+    if cwd not in sys.path:
+        sys.path.insert(0, cwd)
+
+    # Async server loop management
+    loop = asyncio.new_event_loop()
+    asyncio_thread_finished = Event()
+    current_task: asyncio.Task | None = None
+
+    def _run_loop():
+        try:
+            asyncio.set_event_loop(loop)
+            loop.run_forever()
+        finally:
+            asyncio_thread_finished.set()
+
+    Thread(target=_run_loop, daemon=True, name="mcp-hmr-loop").start()
+
+    @register
+    def _stop_all():
+        stop_server()
+        try:
+            loop.call_soon_threadsafe(loop.stop)
+        except RuntimeError:
+            pass
+        try:
+            asyncio_thread_finished.wait(timeout=0.5)
+        except KeyboardInterrupt:
+            pass
+
+    def stop_server():
+        nonlocal current_task
+        if current_task is None:
+            return
+        task = current_task
+        current_task = None
+
+        async def _cancel():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        try:
+            fut = asyncio.run_coroutine_threadsafe(_cancel(), loop)
+            fut.result(timeout=2.0)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def start_server(fn: "ServerCallable"):
+        nonlocal current_task
+
+        def _start() -> asyncio.Future:
+            try:
+                result = fn()
+                if inspect.isawaitable(result):
+                    awaitable_obj = result  # type: ignore[assignment]
+                elif callable(result):
+                    maybe = result()  # type: ignore[call-arg]
+                    if inspect.isawaitable(maybe):
+                        awaitable_obj = maybe  # type: ignore[assignment]
+                    else:
+                        raise TypeError("Entry callable must be or return an awaitable")
+                else:
+                    raise TypeError("Entry callable must be or return an awaitable")
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Failed to start server: %s", exc)
+                raise
+            # Accept any awaitable (not just coroutine) using ensure_future
+            return asyncio.ensure_future(awaitable_obj, loop=loop)
+
+        try:
+            from threading import Event as ThreadEvent
+
+            ready = ThreadEvent()
+
+            # Using call_soon_threadsafe to create task on loop thread
+            def _cb():
+                nonlocal current_task
+                current_task = _start()
+                ready.set()
+
+            loop.call_soon_threadsafe(_cb)
+            if not ready.wait(timeout=1.0):
+                raise TimeoutError("Timeout scheduling server task")
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to schedule server: %s", exc)
+
+    class Reloader(SyncReloader):
+        def __init__(self):
+            super().__init__(str(file), reload_include, reload_exclude)
+            self.error_filter.exclude_filenames.add(__file__)  # exclude error stacks within this file
+
+        @cached_property
+        @override
+        def entry_module(self):
+            if "." in module:
+                __import__(module.rsplit(".", 1)[0])  # ensure parent modules are imported
+
+            if __version__ >= "0.6.4":
+                from reactivity.hmr.core import _loader as loader
+            else:
+                loader = ReactiveModuleLoader(file)  # type: ignore
+
+            spec = ModuleSpec(module, loader, origin=str(file), is_package=is_package)
+            sys.modules[module] = mod = loader.create_module(spec)
+            loader.exec_module(mod)
+            return mod
+
+        @override
+        def run_entry_file(self):
+            stop_server()
+            with self.error_filter:
+                load(self.entry_module)
+                server_callable = getattr(self.entry_module, attr)
+                if not callable(server_callable):
+                    raise TypeError(f"Attribute '{attr}' on module '{module}' is not callable")
+                start_server(server_callable)
+
+        @override
+        def on_events(self, events):
+            if events:
+                paths: list[Path] = []
+                for type, file in events:
+                    path = Path(file).resolve()
+                    if type != Change.deleted and path in ReactiveModule.instances:
+                        paths.append(path)
+                if not paths:
+                    return
+
+                if clear:
+                    print("\033c", end="")
+                logger.warning("Watchfiles detected changes in %s. Reloading...", ", ".join(map(_display_path, paths)))
+            return super().on_events(events)
+
+    logger = getLogger("mcp-hmr")
+    (reloader := Reloader()).keep_watching_until_interrupt()
+    stop_server()
+
+
+def _display_path(path: str | Path):
+    p = Path(path).resolve()
+    try:
+        return f"'{p.relative_to(Path.cwd())}'"
+    except ValueError:
+        return f"'{p}'"
+
+
+if __name__ == "__main__":
+    app()
+

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -14,6 +14,7 @@ from typing import Annotated, override
 
 from typer import Argument, Option, Typer, secho
 
+ServerCallable = Callable[[], Awaitable[object] | object]
 
 app = Typer(help="Hot Module Reloading for MCP-like async servers", add_completion=False, pretty_exceptions_show_locals=False)
 
@@ -60,7 +61,7 @@ def main(
     from reactivity.hmr.utils import load
     from watchfiles import Change
 
-    ServerCallable = Callable[[], Awaitable[object] | object]
+    # no local type aliases
 
     cwd = str(Path.cwd())
     if cwd not in sys.path:
@@ -69,7 +70,7 @@ def main(
     # Async server loop management
     loop = asyncio.new_event_loop()
     asyncio_thread_finished = Event()
-    current_task: asyncio.Task | None = None
+    current_task: asyncio.Future | None = None
 
     def _run_loop():
         try:
@@ -119,11 +120,11 @@ def main(
             try:
                 result = fn()
                 if inspect.isawaitable(result):
-                    awaitable_obj = result  # type: ignore[assignment]
+                    awaitable_obj: Awaitable[object] = result
                 elif callable(result):
-                    maybe = result()  # type: ignore[call-arg]
+                    maybe = result()
                     if inspect.isawaitable(maybe):
-                        awaitable_obj = maybe  # type: ignore[assignment]
+                        awaitable_obj = maybe
                     else:
                         raise TypeError("Entry callable must be or return an awaitable")
                 else:

--- a/packages/mcp-hmr/pyproject.toml
+++ b/packages/mcp-hmr/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "mcp-hmr"
+description = "Hot Module Reloading runner for MCP-like Python servers"
+version = "0.0.1"
+readme = "README.md"
+requires-python = ">=3.12"
+keywords = ["mcp", "hmr", "reload", "devserver"]
+authors = [{ name = "Muspi Merol", email = "me@promplate.dev" }]
+license = "MIT"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "hmr>=0.5.0,<0.8",
+    "typer-slim>=0.15.4,<1",
+]
+
+[project.scripts]
+mcp-hmr = "mcp_hmr:app"
+
+[project.urls]
+Homepage = "https://github.com/promplate/hmr"
+
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+


### PR DESCRIPTION
Implement `mcp-hmr` to provide hot module reloading for MCP-style async Python servers, including a demo.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce8c3829-e7cb-49b6-801f-ec5c186d3d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce8c3829-e7cb-49b6-801f-ec5c186d3d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

