### PR TITLE
feat(mcp-hmr): support MCP Python SDK 2.x

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -39,5 +39,6 @@ It uses the MCP server defined in `main.py`. Now open your favorite editor and m
 
 - Try changing the `echo` tool's return value or the `greet` resource's content.
 - You will see the client output update to reflect your changes without restarting the connection.
+- Try editing `greeting.txt` too. It isn't a Python module, but `main.py` reads it at import time, so HMR tracks it and reloads the server just the same.
 
 This demo shows how to use `mcp-hmr` to enable seamless hot reloading for MCP servers, maintaining the connection between client and server while updating the code on-the-fly.

--- a/examples/mcp/greeting.txt
+++ b/examples/mcp/greeting.txt
@@ -1,0 +1,1 @@
+hello world

--- a/examples/mcp/main.py
+++ b/examples/mcp/main.py
@@ -1,6 +1,7 @@
 from fastmcp import FastMCP
 
 # from mcp.server.fastmcp import FastMCP  # FastMCP v1 is also supported!
+# from mcp.server import MCPServer  # `mcp` 2.x is also supported!
 # from mcp_use import MCPServer  # mcp-use is also supported!
 
 

--- a/examples/mcp/main.py
+++ b/examples/mcp/main.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from fastmcp import FastMCP
 
 # from mcp.server.fastmcp import FastMCP  # FastMCP v1 is also supported!
@@ -7,6 +9,9 @@ from fastmcp import FastMCP
 
 app = FastMCP()
 
+# read at import time, so HMR tracks it: editing `greeting.txt` reloads the module just like editing this file would
+greeting = Path(__file__).parent.joinpath("greeting.txt").read_text()
+
 
 @app.tool()
 def echo(message: str):
@@ -15,7 +20,7 @@ def echo(message: str):
 
 @app.resource("example://greet")
 def greet():
-    return "hello world"
+    return greeting
 
 
 # `mcp-hmr main:app` is equivalent to:

--- a/examples/mcp/pyproject.toml
+++ b/examples/mcp/pyproject.toml
@@ -4,6 +4,7 @@ version = "0"
 requires-python = ">=3.12"
 dependencies = [
     "fastmcp~=2.14.1",
+    "mcp<2",  # fastmcp 2.x needs an mcp 1.x SDK but declares `mcp>=1.24.0` with no upper bound
     "mcp-hmr",
 ]
 

--- a/packages/mcp-hmr/README.md
+++ b/packages/mcp-hmr/README.md
@@ -5,7 +5,14 @@
 
 Provides [Hot Module Reloading](https://pyth-on-line.promplate.dev/hmr) for MCP/FastMCP servers.
 
-It acts as **a drop-in replacement for `mcp run path:app` or `fastmcp run path:app`.** Both [FastMCP v2](https://github.com/jlowin/fastmcp) and the [official python SDK](https://github.com/modelcontextprotocol/python-sdk) are supported. Compatible libraries like [mcp-use](https://github.com/mcp-use/mcp-use/tree/main/libraries/python) are also supported.
+It acts as **a drop-in replacement for `mcp run path:app` or `fastmcp run path:app`.** Both [FastMCP](https://github.com/jlowin/fastmcp) (v2 and v3) and the [official python SDK](https://github.com/modelcontextprotocol/python-sdk) (`mcp` 1.x and 2.x) are supported. Compatible libraries like [mcp-use](https://github.com/mcp-use/mcp-use/tree/main/libraries/python) are also supported.
+
+`mcp` 1.x and 2.x are the same distribution and cannot be installed side by side, so neither is a hard dependency — pick the one matching your server:
+
+```sh
+pip install mcp-hmr[fastmcp]  # FastMCP v2/v3, and any server built on `mcp` 1.x
+pip install mcp-hmr[mcp]      # `mcp` 2.x, i.e. `MCPServer` targets
+```
 
 > [!TIP]
 >
@@ -103,7 +110,9 @@ No extra setup is required when you use the `mcp-hmr` CLI, `mcp_server()`, or `r
 
 > [!NOTE]
 >
-> Internally, `mcp-hmr` temporarily patches `ServerSession.__init__` during FastMCP session initialization and restores it as soon as the managed session is captured. The Python MCP SDK does not expose a cleaner hook for tracking active sessions yet. If this causes conflicts in your setup, please open an [issue](https://github.com/promplate/hmr/issues/new?labels=mcp-hmr) and share the details.
+> On `mcp` 1.x, `mcp-hmr` temporarily patches `ServerSession.__init__` during FastMCP session initialization and restores it as soon as the managed session is captured. That SDK exposes no cleaner hook for tracking active sessions. If this causes conflicts in your setup, please open an [issue](https://github.com/promplate/hmr/issues/new?labels=mcp-hmr) and share the details.
+>
+> On `mcp` 2.x there is no patching: notifications are published on a subscription bus `mcp-hmr` owns. Per the 2026-07-28 spec, they only reach clients that opened a `subscriptions/listen` stream — clients that never subscribe get nothing. Targets must be `MCPServer` instances, since this backend swaps registries in Python rather than proxying over MCP.
 
 > [!NOTE]
 >

--- a/packages/mcp-hmr/README.md
+++ b/packages/mcp-hmr/README.md
@@ -112,7 +112,7 @@ No extra setup is required when you use the `mcp-hmr` CLI, `mcp_server()`, or `r
 >
 > On `mcp` 1.x, `mcp-hmr` temporarily patches `ServerSession.__init__` during FastMCP session initialization and restores it as soon as the managed session is captured. That SDK exposes no cleaner hook for tracking active sessions. If this causes conflicts in your setup, please open an [issue](https://github.com/promplate/hmr/issues/new?labels=mcp-hmr) and share the details.
 >
-> On `mcp` 2.x there is no patching: notifications are published on a subscription bus `mcp-hmr` owns. Per the 2026-07-28 spec, they only reach clients that opened a `subscriptions/listen` stream — clients that never subscribe get nothing. Targets must be `MCPServer` instances, since this backend swaps registries in Python rather than proxying over MCP.
+> On `mcp` 2.x there is no patching: notifications are published on a subscription bus `mcp-hmr` owns. On the 2026-07-28 wire they only reach clients that opened a `subscriptions/listen` stream — there is no other channel to reach the ones that didn't. Targets must be `MCPServer` instances, since this backend swaps registries in Python rather than proxying over MCP; only the tool/resource/prompt registries are swapped, so extensions, custom routes and middleware added on reload won't take effect. HTTP transport also gets no CORS there, as `MCPServer`'s runners take no middleware.
 
 > [!NOTE]
 >

--- a/packages/mcp-hmr/README.md
+++ b/packages/mcp-hmr/README.md
@@ -35,6 +35,8 @@ mcp-hmr main:app
 
 Now, whenever you save changes to your source code, the server will automatically reload without dropping the connection to the client.
 
+This isn't limited to `.py` files: any file your modules read at import time — a prompt template, a JSON config, a `.md` — is tracked too, so editing it reloads the server just the same. See [`examples/mcp`](https://github.com/promplate/hmr/tree/HEAD/examples/mcp) for a runnable demo.
+
 The CLI provides a simple way to get started, but if you need more control, you can also use `mcp_hmr` programmatically.
 
 ### Options

--- a/packages/mcp-hmr/README.md
+++ b/packages/mcp-hmr/README.md
@@ -13,6 +13,8 @@ It acts as **a drop-in replacement for `mcp run path:app` or `fastmcp run path:a
 pip install mcp-hmr
 ```
 
+One exception: on `mcp` 1.x the target is fronted by a [FastMCP](https://github.com/jlowin/fastmcp) proxy, so `fastmcp` has to be importable. That's free if your server is a `fastmcp` one, but `mcp.server.fastmcp.FastMCP` and `mcp_use.MCPServer` targets need `pip install fastmcp` alongside.
+
 > [!TIP]
 >
 > Here's the thing: With this package, you don't need to restart your MCP server on every code change. Just save your files, and the server automatically uses the latest code without dropping client connections.

--- a/packages/mcp-hmr/README.md
+++ b/packages/mcp-hmr/README.md
@@ -7,11 +7,10 @@ Provides [Hot Module Reloading](https://pyth-on-line.promplate.dev/hmr) for MCP/
 
 It acts as **a drop-in replacement for `mcp run path:app` or `fastmcp run path:app`.** Both [FastMCP](https://github.com/jlowin/fastmcp) (v2 and v3) and the [official python SDK](https://github.com/modelcontextprotocol/python-sdk) (`mcp` 1.x and 2.x) are supported. Compatible libraries like [mcp-use](https://github.com/mcp-use/mcp-use/tree/main/libraries/python) are also supported.
 
-`mcp` 1.x and 2.x are the same distribution and cannot be installed side by side, so neither is a hard dependency — pick the one matching your server:
+`mcp` 1.x and 2.x are the same distribution and cannot be installed side by side. Neither is a dependency of `mcp-hmr` — install it next to the server you already have, and it adapts to whichever generation is there:
 
 ```sh
-pip install mcp-hmr[fastmcp]  # FastMCP v2/v3, and any server built on `mcp` 1.x
-pip install mcp-hmr[mcp]      # `mcp` 2.x, i.e. `MCPServer` targets
+pip install mcp-hmr
 ```
 
 > [!TIP]
@@ -112,7 +111,8 @@ No extra setup is required when you use the `mcp-hmr` CLI, `mcp_server()`, or `r
 >
 > On `mcp` 1.x, `mcp-hmr` temporarily patches `ServerSession.__init__` during FastMCP session initialization and restores it as soon as the managed session is captured. That SDK exposes no cleaner hook for tracking active sessions. If this causes conflicts in your setup, please open an [issue](https://github.com/promplate/hmr/issues/new?labels=mcp-hmr) and share the details.
 >
-> On `mcp` 2.x there is no patching: notifications are published on a subscription bus `mcp-hmr` owns. On the 2026-07-28 wire they only reach clients that opened a `subscriptions/listen` stream — there is no other channel to reach the ones that didn't. Targets must be `MCPServer` instances, since this backend swaps registries in Python rather than proxying over MCP; only the tool/resource/prompt registries are swapped, so extensions, custom routes and middleware added on reload won't take effect. HTTP transport also gets no CORS there, as `MCPServer`'s runners take no middleware.
+> `MCPServer` targets (`mcp` 2.x) take a different route, since that SDK has neither mount nor proxy: their registries are swapped into a stable outer server in Python rather than proxied over MCP. So only the tool/resource/prompt registries are swapped — extensions, custom routes and middleware added on reload won't take effect, and HTTP transport gets no CORS, as `MCPServer`'s runners take no middleware. There is also no patching: notifications are published on a subscription bus `mcp-hmr` owns, and on the 2026-07-28 wire they only reach clients that opened a `subscriptions/listen` stream.
+
 
 > [!NOTE]
 >

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -43,21 +43,23 @@ def patch_session_init():
 def proxy_backend():
     """For mcp 1.x, where nothing can swap a live server's contents: front the target with a FastMCP proxy."""
 
+    from asyncio import TaskGroup
     from contextlib import contextmanager, suppress
-    from inspect import signature
 
     from fastmcp import FastMCP
     from mcp.server.session import ServerSession
 
-    try:
-        from fastmcp.server.providers.proxy import ProxyClient  # fastmcp 3.x
+    try:  # fastmcp 3 moved the proxy module, split `create_proxy` out of `FastMCP.as_proxy`, and dropped the `include_fastmcp_meta` kwarg together with the metadata it suppressed
+        from fastmcp.server import create_proxy
+        from fastmcp.server.providers.proxy import ProxyClient
+
+        fastmcp3 = True
     except ImportError:
         from fastmcp.server.proxy import ProxyClient
 
-    # fastmcp 3 dropped this kwarg together with the metadata it used to suppress
-    no_meta = {"include_fastmcp_meta": False} if "include_fastmcp_meta" in signature(FastMCP.__init__).parameters else {}
+        fastmcp3 = False
 
-    base_app = FastMCP(name="proxy", **no_meta)
+    base_app = FastMCP(name="proxy") if fastmcp3 else FastMCP(name="proxy", include_fastmcp_meta=False)
 
     original_run = base_app._mcp_server.run  # noqa: SLF001
 
@@ -70,8 +72,7 @@ def proxy_backend():
 
     base_app._mcp_server.run = run_with_patched_session  # noqa: SLF001
 
-    if hasattr(base_app, "providers"):  # fastmcp 3 replaced the three `_mounted_servers` lists with one provider list
-        from fastmcp.server import create_proxy  # fastmcp 3 split this out of `FastMCP.as_proxy`
+    if fastmcp3:  # fastmcp 3 replaced the three `_mounted_servers` lists with one provider list
 
         @contextmanager
         def mount(app):
@@ -110,14 +111,11 @@ def proxy_backend():
                 await session.send_log_message("warning", e)
 
     async def notify():
-        for session in list(active_sessions):
-            await notify_list_changed(session)
+        async with TaskGroup() as tg:  # one slow client must not delay the others
+            for session in list(active_sessions):
+                tg.create_task(notify_list_changed(session))
 
     return base_app, mount, notify
-
-
-# every registry an MCPServer looks things up in — swapping these swaps the whole served surface
-_REGISTRIES = {"_tool_manager": ("_tools",), "_resource_manager": ("_resources", "_templates"), "_prompt_manager": ("_prompts",)}
 
 
 def swap_backend():
@@ -133,21 +131,21 @@ def swap_backend():
     from mcp.server import MCPServer
     from mcp.server.subscriptions import InMemorySubscriptionBus, PromptsListChanged, ResourcesListChanged, ToolsListChanged
 
+    # every registry an MCPServer looks things up in — swapping these swaps the whole served surface
+    registries = ("_tool_manager", "_tools"), ("_resource_manager", "_resources"), ("_resource_manager", "_templates"), ("_prompt_manager", "_prompts")
+
     bus = InMemorySubscriptionBus()
     base_app = MCPServer("proxy", subscriptions=bus)
 
-    def read(app: MCPServer):
-        return {(manager, slot): getattr(getattr(app, manager), slot) for manager, slots in _REGISTRIES.items() for slot in slots}
+    def install(app: MCPServer):
+        for manager, slot in registries:
+            setattr(getattr(base_app, manager), slot, getattr(getattr(app, manager), slot))
 
-    def install(registries):
-        for (manager, slot), registry in registries.items():
-            setattr(getattr(base_app, manager), slot, registry)
-
-    empty = read(base_app)  # captured before anything is mounted
+    empty = MCPServer("empty")  # a pristine server, to restore the registries from on unmount
 
     @contextmanager
     def mount(app: MCPServer):
-        install(read(app))
+        install(app)
         try:
             yield
         finally:  # unmount
@@ -247,12 +245,13 @@ def mcp_server(target: str):
     return _()
 
 
-def _mcpserver_kwargs(kwargs: dict, path_key: str):
+def _mcpserver_kwargs(runner, kwargs: dict, path_key: str):
     """MCPServer's runners accept a subset of FastMCP's options, and name the route path per transport."""
-    options = {k: v for k, v in kwargs.items() if k in {"host", "port", "json_response", "stateless_http"} and v is not None}
+    from inspect import signature
+
     if path := kwargs.get("path"):
-        options[path_key] = path
-    return options
+        kwargs = kwargs | {path_key: path}
+    return {k: v for k, v in kwargs.items() if k in signature(runner).parameters and v is not None}
 
 
 async def run_with_hmr(target: str, log_level: str | None = None, transport="stdio", **kwargs):
@@ -262,9 +261,9 @@ async def run_with_hmr(target: str, log_level: str | None = None, transport="std
                 case "stdio":
                     return await mcp.run_stdio_async()
                 case "sse":
-                    return await mcp.run_sse_async(**_mcpserver_kwargs(kwargs, "sse_path"))
+                    return await mcp.run_sse_async(**_mcpserver_kwargs(mcp.run_sse_async, kwargs, "sse_path"))
                 case _:
-                    return await mcp.run_streamable_http_async(**_mcpserver_kwargs(kwargs, "streamable_http_path"))
+                    return await mcp.run_streamable_http_async(**_mcpserver_kwargs(mcp.run_streamable_http_async, kwargs, "streamable_http_path"))
         match transport:
             case "stdio":
                 await mcp.run_stdio_async(show_banner=False, log_level=log_level)

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -5,7 +5,7 @@ from importlib.util import find_spec, module_from_spec
 from pathlib import Path
 from weakref import WeakSet
 
-__version__ = "0.0.3.5"
+__version__ = "0.0.4"
 
 __all__ = "mcp_server", "run_with_hmr"
 
@@ -40,21 +40,24 @@ def patch_session_init():
     return unpatch
 
 
-def mcp_server(target: str):
-    module, attr = target.rsplit(":", 1)
+def proxy_backend():
+    """For mcp 1.x, where nothing can swap a live server's contents: front the target with a FastMCP proxy."""
 
-    from asyncio import Event, Lock, TaskGroup
-    from contextlib import asynccontextmanager, contextmanager, suppress
+    from contextlib import contextmanager, suppress
+    from inspect import signature
 
-    import mcp.server
     from fastmcp import FastMCP
-    from fastmcp.server.proxy import ProxyClient
     from mcp.server.session import ServerSession
-    from reactivity import async_effect, derived
-    from reactivity.hmr.core import HMR_CONTEXT, AsyncReloader, _loader
-    from reactivity.hmr.hooks import call_post_reload_hooks, call_pre_reload_hooks
 
-    base_app = FastMCP(name="proxy", include_fastmcp_meta=False)
+    try:
+        from fastmcp.server.providers.proxy import ProxyClient  # fastmcp 3.x
+    except ImportError:
+        from fastmcp.server.proxy import ProxyClient
+
+    # fastmcp 3 dropped this kwarg together with the metadata it used to suppress
+    no_meta = {"include_fastmcp_meta": False} if "include_fastmcp_meta" in signature(FastMCP.__init__).parameters else {}
+
+    base_app = FastMCP(name="proxy", **no_meta)
 
     original_run = base_app._mcp_server.run  # noqa: SLF001
 
@@ -67,33 +70,37 @@ def mcp_server(target: str):
 
     base_app._mcp_server.run = run_with_patched_session  # noqa: SLF001
 
-    @contextmanager
-    def mount(app: FastMCP | mcp.server.FastMCP):
-        base_app.mount(proxy := FastMCP.as_proxy(ProxyClient(app)), as_proxy=False)
-        try:
-            yield
-        finally:  # unmount
-            for mounted_server in list(base_app._mounted_servers):  # noqa: SLF001
-                if mounted_server.server is proxy:
-                    base_app._mounted_servers.remove(mounted_server)  # noqa: SLF001
-                    # for older FastMCP versions
-                    with suppress(AttributeError):
-                        base_app._tool_manager._mounted_servers.remove(mounted_server)  # type: ignore  # noqa: SLF001
-                        base_app._resource_manager._mounted_servers.remove(mounted_server)  # type: ignore  # noqa: SLF001
-                        base_app._prompt_manager._mounted_servers.remove(mounted_server)  # type: ignore  # noqa: SLF001
-                    break
+    if hasattr(base_app, "providers"):  # fastmcp 3 replaced the three `_mounted_servers` lists with one provider list
+        from fastmcp.server import create_proxy  # fastmcp 3 split this out of `FastMCP.as_proxy`
 
-    lock = Lock()
+        @contextmanager
+        def mount(app):
+            base_app.mount(create_proxy(ProxyClient(app)))
+            provider = base_app.providers[-1]
+            try:
+                yield
+            finally:  # unmount
+                base_app.providers.remove(provider)
 
-    async def using(app: FastMCP | mcp.server.FastMCP, stop_event: Event, finish_event: Event):
-        async with lock:
-            with mount(app):
-                for session in active_sessions:
-                    tg.create_task(_notify_list_changed(session))
-                await stop_event.wait()
-                finish_event.set()
+    else:
 
-    async def _notify_list_changed(session: ServerSession):
+        @contextmanager
+        def mount(app):
+            base_app.mount(proxy := FastMCP.as_proxy(ProxyClient(app)), as_proxy=False)
+            try:
+                yield
+            finally:  # unmount
+                for mounted_server in list(base_app._mounted_servers):  # noqa: SLF001
+                    if mounted_server.server is proxy:
+                        base_app._mounted_servers.remove(mounted_server)  # noqa: SLF001
+                        # for older FastMCP versions
+                        with suppress(AttributeError):
+                            base_app._tool_manager._mounted_servers.remove(mounted_server)  # type: ignore  # noqa: SLF001
+                            base_app._resource_manager._mounted_servers.remove(mounted_server)  # type: ignore  # noqa: SLF001
+                            base_app._prompt_manager._mounted_servers.remove(mounted_server)  # type: ignore  # noqa: SLF001
+                        break
+
+    async def notify_list_changed(session: ServerSession):
         try:
             await session.send_tool_list_changed()
             await session.send_resource_list_changed()
@@ -101,6 +108,86 @@ def mcp_server(target: str):
         except Exception as e:
             with suppress(Exception):
                 await session.send_log_message("warning", e)
+
+    async def notify():
+        for session in list(active_sessions):
+            await notify_list_changed(session)
+
+    return base_app, mount, notify
+
+
+# every registry an MCPServer looks things up in — swapping these swaps the whole served surface
+_REGISTRIES = {"_tool_manager": ("_tools",), "_resource_manager": ("_resources", "_templates"), "_prompt_manager": ("_prompts",)}
+
+
+def swap_backend():
+    """For mcp 2.x, which has no mount or proxy: swap the target's registries into a stable outer server.
+
+    Unlike the proxy backend this talks Python, not MCP, so the target must be an `MCPServer` too.
+    Notifications go through the subscription bus, which only reaches clients that opened a
+    `subscriptions/listen` stream — the 2026-07-28 spec forbids pushing to the ones that didn't.
+    """
+
+    from contextlib import contextmanager
+
+    from mcp.server import MCPServer
+    from mcp.server.subscriptions import InMemorySubscriptionBus, PromptsListChanged, ResourcesListChanged, ToolsListChanged
+
+    bus = InMemorySubscriptionBus()
+    base_app = MCPServer("proxy", subscriptions=bus)
+
+    def read(app: MCPServer):
+        return {(manager, slot): getattr(getattr(app, manager), slot) for manager, slots in _REGISTRIES.items() for slot in slots}
+
+    def install(registries):
+        for (manager, slot), registry in registries.items():
+            setattr(getattr(base_app, manager), slot, registry)
+
+    empty = read(base_app)  # captured before anything is mounted
+
+    @contextmanager
+    def mount(app: MCPServer):
+        install(read(app))
+        try:
+            yield
+        finally:  # unmount
+            install(empty)
+
+    async def notify():
+        for event in (ToolsListChanged(), ResourcesListChanged(), PromptsListChanged()):
+            await bus.publish(event)
+
+    return base_app, mount, notify
+
+
+def pick_backend():
+    try:
+        from mcp.server import MCPServer  # noqa: F401
+    except ImportError:  # mcp 1.x
+        return proxy_backend()
+    return swap_backend()
+
+
+def mcp_server(target: str):
+    module, attr = target.rsplit(":", 1)
+
+    from asyncio import Event, Lock, TaskGroup
+    from contextlib import asynccontextmanager
+
+    from reactivity import async_effect, derived
+    from reactivity.hmr.core import HMR_CONTEXT, AsyncReloader, _loader
+    from reactivity.hmr.hooks import call_post_reload_hooks, call_pre_reload_hooks
+
+    base_app, mount, notify = pick_backend()
+
+    lock = Lock()
+
+    async def using(app, stop_event: Event, finish_event: Event):
+        async with lock:
+            with mount(app):
+                tg.create_task(notify())
+                await stop_event.wait()
+                finish_event.set()
 
     if Path(module).is_file():  # module:attr
 
@@ -160,8 +247,24 @@ def mcp_server(target: str):
     return _()
 
 
+def _mcpserver_kwargs(kwargs: dict, path_key: str):
+    """MCPServer's runners accept a subset of FastMCP's options, and name the route path per transport."""
+    options = {k: v for k, v in kwargs.items() if k in {"host", "port", "json_response", "stateless_http"} and v is not None}
+    if path := kwargs.get("path"):
+        options[path_key] = path
+    return options
+
+
 async def run_with_hmr(target: str, log_level: str | None = None, transport="stdio", **kwargs):
     async with mcp_server(target) as mcp:
+        if not hasattr(mcp, "run_async"):  # an MCPServer, which has neither run_async nor any log_level option
+            match transport:
+                case "stdio":
+                    return await mcp.run_stdio_async()
+                case "sse":
+                    return await mcp.run_sse_async(**_mcpserver_kwargs(kwargs, "sse_path"))
+                case _:
+                    return await mcp.run_streamable_http_async(**_mcpserver_kwargs(kwargs, "streamable_http_path"))
         match transport:
             case "stdio":
                 await mcp.run_stdio_async(show_banner=False, log_level=log_level)

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -258,18 +258,23 @@ def mcp_server(target: str):
     return _()
 
 
-def _mcpserver_kwargs(runner, kwargs: dict, path_key: str):
-    """MCPServer's runners take a narrower option set than FastMCP's, and name the route path per transport.
+def _supported(runner, kwargs: dict):
+    """Runner signatures drift across SDK versions (`log_level` only reached `run_stdio_async` in fastmcp 2.13, and `MCPServer`'s runners take a far narrower set).
 
     Filtering by signature also drops the `None` defaults argparse supplies, so the runner's own defaults win.
     """
     from inspect import signature
 
+    return {k: v for k, v in kwargs.items() if k in signature(runner).parameters and v is not None}
+
+
+def _mcpserver_kwargs(runner, kwargs: dict, path_key: str):
+    """MCPServer's runners name the route path per transport, and take no middleware."""
     if path := kwargs.get("path"):
         kwargs = kwargs | {path_key: path}
     if kwargs.get("middleware"):
         print("mcp-hmr: CORS is unavailable on mcp 2.x — MCPServer's runners take no middleware", file=sys.stderr)
-    return {k: v for k, v in kwargs.items() if k in signature(runner).parameters and v is not None}
+    return _supported(runner, kwargs)
 
 
 async def run_with_hmr(target: str, log_level: str | None = None, transport="stdio", **kwargs):
@@ -282,19 +287,20 @@ async def run_with_hmr(target: str, log_level: str | None = None, transport="std
                     return await mcp.run_sse_async(**_mcpserver_kwargs(mcp.run_sse_async, kwargs, "sse_path"))
                 case _:
                     return await mcp.run_streamable_http_async(**_mcpserver_kwargs(mcp.run_streamable_http_async, kwargs, "streamable_http_path"))
+        kwargs |= {"log_level": log_level}
         match transport:
             case "stdio":
-                await mcp.run_stdio_async(show_banner=False, log_level=log_level)
+                await mcp.run_stdio_async(**_supported(mcp.run_stdio_async, kwargs | {"show_banner": False}))
             case "http" | "streamable-http":
-                await mcp.run_http_async(log_level=log_level, **kwargs)
+                await mcp.run_http_async(**_supported(mcp.run_http_async, kwargs))
             case "sse":
                 # for older FastMCP versions
                 if hasattr(mcp, "run_sse_async"):
-                    await mcp.run_sse_async(log_level=log_level, **kwargs)
+                    await mcp.run_sse_async(**_supported(mcp.run_sse_async, kwargs))
                 else:
-                    await mcp.run_http_async(transport="sse", log_level=log_level, **kwargs)
+                    await mcp.run_http_async(transport="sse", **_supported(mcp.run_http_async, kwargs))
             case _:
-                await mcp.run_async(transport, log_level=log_level, **kwargs)
+                await mcp.run_async(transport, **_supported(mcp.run_async, kwargs))
 
 
 def cli(argv: list[str] = sys.argv[1:]):

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -45,11 +45,12 @@ def proxy_backend():
 
     from asyncio import TaskGroup
     from contextlib import contextmanager, suppress
+    from inspect import signature
 
     from fastmcp import FastMCP
     from mcp.server.session import ServerSession
 
-    try:  # fastmcp 3 moved the proxy module, split `create_proxy` out of `FastMCP.as_proxy`, and dropped the `include_fastmcp_meta` kwarg together with the metadata it suppressed
+    try:  # fastmcp 3 moved the proxy module and split `create_proxy` out of `FastMCP.as_proxy`
         from fastmcp.server import create_proxy
         from fastmcp.server.providers.proxy import ProxyClient
 
@@ -59,7 +60,10 @@ def proxy_backend():
 
         fastmcp3 = False
 
-    base_app = FastMCP(name="proxy") if fastmcp3 else FastMCP(name="proxy", include_fastmcp_meta=False)
+    # this kwarg only exists between fastmcp 2.11 and 3.0 — fastmcp 3 dropped it together with the metadata it used to suppress
+    no_meta = {"include_fastmcp_meta": False} if "include_fastmcp_meta" in signature(FastMCP.__init__).parameters else {}
+
+    base_app = FastMCP(name="proxy", **no_meta)
 
     original_run = base_app._mcp_server.run  # noqa: SLF001
 
@@ -72,7 +76,7 @@ def proxy_backend():
 
     base_app._mcp_server.run = run_with_patched_session  # noqa: SLF001
 
-    if fastmcp3:  # fastmcp 3 replaced the three `_mounted_servers` lists with one provider list
+    if fastmcp3:  # fastmcp 3 replaced `_mounted_servers` (and the per-manager copies older 2.x kept) with a single `providers` list
 
         @contextmanager
         def mount(app):
@@ -108,7 +112,7 @@ def proxy_backend():
             await session.send_prompt_list_changed()
         except Exception as e:
             with suppress(Exception):
-                await session.send_log_message("warning", e)
+                await session.send_log_message("warning", str(e))  # the raw exception would only fail to serialize later, in the transport's writer task
 
     async def notify():
         async with TaskGroup() as tg:  # one slow client must not delay the others
@@ -123,7 +127,7 @@ def swap_backend():
 
     Unlike the proxy backend this talks Python, not MCP, so the target must be an `MCPServer` too.
     Notifications go through the subscription bus, which only reaches clients that opened a
-    `subscriptions/listen` stream — the 2026-07-28 spec forbids pushing to the ones that didn't.
+    `subscriptions/listen` stream — on the 2026-07-28 wire there is no other channel to reach them.
     """
 
     from contextlib import contextmanager
@@ -131,21 +135,24 @@ def swap_backend():
     from mcp.server import MCPServer
     from mcp.server.subscriptions import InMemorySubscriptionBus, PromptsListChanged, ResourcesListChanged, ToolsListChanged
 
-    # every registry an MCPServer looks things up in — swapping these swaps the whole served surface
+    # every registry an MCPServer looks tools/resources/prompts up in — extensions, custom routes, middleware and lifespan stay the outer server's
     registries = ("_tool_manager", "_tools"), ("_resource_manager", "_resources"), ("_resource_manager", "_templates"), ("_prompt_manager", "_prompts")
 
     bus = InMemorySubscriptionBus()
     base_app = MCPServer("proxy", subscriptions=bus)
 
-    def install(app: MCPServer):
-        for manager, slot in registries:
-            setattr(getattr(base_app, manager), slot, getattr(getattr(app, manager), slot))
+    def read(app: MCPServer):  # the containers themselves, not copies — while mounted, the target's live registries *are* the served ones
+        return [getattr(getattr(app, manager), slot) for manager, slot in registries]
 
-    empty = MCPServer("empty")  # a pristine server, to restore the registries from on unmount
+    def install(values):
+        for (manager, slot), value in zip(registries, values, strict=True):
+            setattr(getattr(base_app, manager), slot, value)
+
+    empty = read(base_app)  # captured before anything is mounted
 
     @contextmanager
     def mount(app: MCPServer):
-        install(app)
+        install(read(app))
         try:
             yield
         finally:  # unmount
@@ -246,17 +253,22 @@ def mcp_server(target: str):
 
 
 def _mcpserver_kwargs(runner, kwargs: dict, path_key: str):
-    """MCPServer's runners accept a subset of FastMCP's options, and name the route path per transport."""
+    """MCPServer's runners take a narrower option set than FastMCP's, and name the route path per transport.
+
+    Filtering by signature also drops the `None` defaults argparse supplies, so the runner's own defaults win.
+    """
     from inspect import signature
 
     if path := kwargs.get("path"):
         kwargs = kwargs | {path_key: path}
+    if kwargs.get("middleware"):
+        print("mcp-hmr: CORS is unavailable on mcp 2.x — MCPServer's runners take no middleware", file=sys.stderr)
     return {k: v for k, v in kwargs.items() if k in signature(runner).parameters and v is not None}
 
 
 async def run_with_hmr(target: str, log_level: str | None = None, transport="stdio", **kwargs):
     async with mcp_server(target) as mcp:
-        if not hasattr(mcp, "run_async"):  # an MCPServer, which has neither run_async nor any log_level option
+        if not hasattr(mcp, "run_async"):  # an MCPServer, which has no run_async, and whose runners take no log_level
             match transport:
                 case "stdio":
                     return await mcp.run_stdio_async()

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -45,7 +45,6 @@ def proxy_backend():
 
     from asyncio import TaskGroup
     from contextlib import contextmanager, suppress
-    from inspect import signature
 
     from fastmcp import FastMCP
     from mcp.server.session import ServerSession
@@ -60,8 +59,8 @@ def proxy_backend():
 
         fastmcp3 = False
 
-    # this kwarg only exists between fastmcp 2.11 and 3.0 — fastmcp 3 dropped it together with the metadata it used to suppress
-    no_meta = {"include_fastmcp_meta": False} if "include_fastmcp_meta" in signature(FastMCP.__init__).parameters else {}
+    # fastmcp 3 dropped this kwarg together with the metadata it used to suppress
+    no_meta = {} if fastmcp3 else {"include_fastmcp_meta": False}
 
     base_app = FastMCP(name="proxy", **no_meta)
 

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -3,6 +3,7 @@ from importlib import import_module
 from importlib.machinery import ModuleSpec
 from importlib.util import find_spec, module_from_spec
 from pathlib import Path
+from typing import Any
 from weakref import WeakSet
 
 __version__ = "0.0.4"
@@ -50,8 +51,8 @@ def proxy_backend():
     from mcp.server.session import ServerSession
 
     try:  # fastmcp 3 moved the proxy module and split `create_proxy` out of `FastMCP.as_proxy`
-        from fastmcp.server import create_proxy
-        from fastmcp.server.providers.proxy import ProxyClient
+        from fastmcp.server import create_proxy  # type: ignore
+        from fastmcp.server.providers.proxy import ProxyClient  # type: ignore
 
         fastmcp3 = True
     except ImportError:
@@ -60,7 +61,7 @@ def proxy_backend():
         fastmcp3 = False
 
     # fastmcp 3 dropped this kwarg together with the metadata it used to suppress
-    no_meta = {} if fastmcp3 else {"include_fastmcp_meta": False}
+    no_meta: dict[str, Any] = {} if fastmcp3 else {"include_fastmcp_meta": False}
 
     base_app = FastMCP(name="proxy", **no_meta)
 
@@ -79,12 +80,12 @@ def proxy_backend():
 
         @contextmanager
         def mount(app):
-            base_app.mount(create_proxy(ProxyClient(app)))
-            provider = base_app.providers[-1]
+            base_app.mount(create_proxy(ProxyClient(app)))  # type: ignore
+            provider = base_app.providers[-1]  # type: ignore
             try:
                 yield
             finally:  # unmount
-                base_app.providers.remove(provider)
+                base_app.providers.remove(provider)  # type: ignore
 
     else:
 
@@ -272,20 +273,20 @@ async def run_with_hmr(target: str, log_level: str | None = None, transport="std
                 case "stdio":
                     return await mcp.run_stdio_async()
                 case "sse":
-                    return await mcp.run_sse_async(**_mcpserver_kwargs(mcp.run_sse_async, kwargs, "sse_path"))
+                    return await mcp.run_sse_async(**_mcpserver_kwargs(mcp.run_sse_async, kwargs, "sse_path"))  # type: ignore
                 case _:
-                    return await mcp.run_streamable_http_async(**_mcpserver_kwargs(mcp.run_streamable_http_async, kwargs, "streamable_http_path"))
+                    return await mcp.run_streamable_http_async(**_mcpserver_kwargs(mcp.run_streamable_http_async, kwargs, "streamable_http_path"))  # type: ignore
         match transport:
             case "stdio":
-                await mcp.run_stdio_async(show_banner=False, log_level=log_level)
+                await mcp.run_stdio_async(show_banner=False, log_level=log_level)  # type: ignore
             case "http" | "streamable-http":
-                await mcp.run_http_async(log_level=log_level, **kwargs)
+                await mcp.run_http_async(log_level=log_level, **kwargs)  # type: ignore
             case "sse":
                 # for older FastMCP versions
                 if hasattr(mcp, "run_sse_async"):
                     await mcp.run_sse_async(log_level=log_level, **kwargs)  # type: ignore
                 else:
-                    await mcp.run_http_async(transport="sse", log_level=log_level, **kwargs)
+                    await mcp.run_http_async(transport="sse", log_level=log_level, **kwargs)  # type: ignore
             case _:
                 await mcp.run_async(transport, log_level=log_level, **kwargs)  # type: ignore
 

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -132,8 +132,8 @@ def swap_backend():
 
     from contextlib import contextmanager
 
-    from mcp.server import MCPServer
-    from mcp.server.subscriptions import InMemorySubscriptionBus, PromptsListChanged, ResourcesListChanged, ToolsListChanged
+    from mcp.server import MCPServer  # type: ignore
+    from mcp.server.subscriptions import InMemorySubscriptionBus, PromptsListChanged, ResourcesListChanged, ToolsListChanged  # type: ignore
 
     # every registry an MCPServer looks tools/resources/prompts up in — extensions, custom routes, middleware and lifespan stay the outer server's
     registries = ("_tool_manager", "_tools"), ("_resource_manager", "_resources"), ("_resource_manager", "_templates"), ("_prompt_manager", "_prompts")
@@ -167,7 +167,7 @@ def swap_backend():
 
 def pick_backend(app):
     try:
-        from mcp.server import MCPServer
+        from mcp.server import MCPServer  # type: ignore
     except ImportError:  # mcp 1.x
         return proxy_backend()
     # on mcp 2.x a FastMCP target still exists (fastmcp 4 runs on it) and must go through the proxy — `swap_backend` only understands `MCPServer` registries

--- a/packages/mcp-hmr/mcp_hmr.py
+++ b/packages/mcp-hmr/mcp_hmr.py
@@ -165,12 +165,13 @@ def swap_backend():
     return base_app, mount, notify
 
 
-def pick_backend():
+def pick_backend(app):
     try:
-        from mcp.server import MCPServer  # noqa: F401
+        from mcp.server import MCPServer
     except ImportError:  # mcp 1.x
         return proxy_backend()
-    return swap_backend()
+    # on mcp 2.x a FastMCP target still exists (fastmcp 4 runs on it) and must go through the proxy — `swap_backend` only understands `MCPServer` registries
+    return swap_backend() if isinstance(app, MCPServer) else proxy_backend()
 
 
 def mcp_server(target: str):
@@ -183,7 +184,9 @@ def mcp_server(target: str):
     from reactivity.hmr.core import HMR_CONTEXT, AsyncReloader, _loader
     from reactivity.hmr.hooks import call_post_reload_hooks, call_pre_reload_hooks
 
-    base_app, mount, notify = pick_backend()
+    base_app: Any = ...  # base_app / mount / notify are picked from the target itself on first load
+    mount: Any = ...
+    notify: Any = ...
 
     lock = Lock()
 
@@ -214,13 +217,16 @@ def mcp_server(target: str):
 
     @async_effect(context=HMR_CONTEXT, call_immediately=False)
     async def main():
-        nonlocal stop_event, finish_event
+        nonlocal stop_event, finish_event, base_app, mount, notify
 
         if stop_event is not None:
             stop_event.set()
             await finish_event.wait()
 
         app = get_app()
+
+        if base_app is ...:
+            base_app, mount, notify = pick_backend(app)
 
         tg.create_task(using(app, stop_event := Event(), finish_event := Event()))
 
@@ -273,22 +279,22 @@ async def run_with_hmr(target: str, log_level: str | None = None, transport="std
                 case "stdio":
                     return await mcp.run_stdio_async()
                 case "sse":
-                    return await mcp.run_sse_async(**_mcpserver_kwargs(mcp.run_sse_async, kwargs, "sse_path"))  # type: ignore
+                    return await mcp.run_sse_async(**_mcpserver_kwargs(mcp.run_sse_async, kwargs, "sse_path"))
                 case _:
-                    return await mcp.run_streamable_http_async(**_mcpserver_kwargs(mcp.run_streamable_http_async, kwargs, "streamable_http_path"))  # type: ignore
+                    return await mcp.run_streamable_http_async(**_mcpserver_kwargs(mcp.run_streamable_http_async, kwargs, "streamable_http_path"))
         match transport:
             case "stdio":
-                await mcp.run_stdio_async(show_banner=False, log_level=log_level)  # type: ignore
+                await mcp.run_stdio_async(show_banner=False, log_level=log_level)
             case "http" | "streamable-http":
-                await mcp.run_http_async(log_level=log_level, **kwargs)  # type: ignore
+                await mcp.run_http_async(log_level=log_level, **kwargs)
             case "sse":
                 # for older FastMCP versions
                 if hasattr(mcp, "run_sse_async"):
-                    await mcp.run_sse_async(log_level=log_level, **kwargs)  # type: ignore
+                    await mcp.run_sse_async(log_level=log_level, **kwargs)
                 else:
-                    await mcp.run_http_async(transport="sse", log_level=log_level, **kwargs)  # type: ignore
+                    await mcp.run_http_async(transport="sse", log_level=log_level, **kwargs)
             case _:
-                await mcp.run_async(transport, log_level=log_level, **kwargs)  # type: ignore
+                await mcp.run_async(transport, log_level=log_level, **kwargs)
 
 
 def cli(argv: list[str] = sys.argv[1:]):

--- a/packages/mcp-hmr/pyproject.toml
+++ b/packages/mcp-hmr/pyproject.toml
@@ -12,10 +12,14 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "fastmcp>=2.2.0,<3",
     "hmr~=0.7.0",
 ]
 dynamic = ["version"]
+
+# `fastmcp` pins `mcp<2`, so depending on it unconditionally would rule out mcp 2.x forever
+[project.optional-dependencies]
+fastmcp = ["fastmcp>=2.2.0,<4"]
+mcp = ["mcp>=2"]
 
 [tool.pdm.version]
 source = "file"

--- a/packages/mcp-hmr/pyproject.toml
+++ b/packages/mcp-hmr/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 # `fastmcp` pins `mcp<2`, so depending on it unconditionally would rule out mcp 2.x forever
 [project.optional-dependencies]
-fastmcp = ["fastmcp>=2.2.0,<4"]
+fastmcp = ["fastmcp>=2.12,<4"]
 mcp = ["mcp>=2"]
 
 [tool.pdm.version]

--- a/packages/mcp-hmr/pyproject.toml
+++ b/packages/mcp-hmr/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 # `fastmcp` pins `mcp<2`, so depending on it unconditionally would rule out mcp 2.x forever
 [project.optional-dependencies]
 fastmcp = ["fastmcp>=2.12,<4"]
-mcp = ["mcp>=2"]
+mcp = ["mcp>=2,<3"]
 
 [tool.pdm.version]
 source = "file"

--- a/packages/mcp-hmr/pyproject.toml
+++ b/packages/mcp-hmr/pyproject.toml
@@ -16,11 +16,6 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-# `fastmcp` pins `mcp<2`, so depending on it unconditionally would rule out mcp 2.x forever
-[project.optional-dependencies]
-fastmcp = ["fastmcp>=2.12,<4"]
-mcp = ["mcp>=1,<3"]
-
 [tool.pdm.version]
 source = "file"
 path = "mcp_hmr.py"

--- a/packages/mcp-hmr/pyproject.toml
+++ b/packages/mcp-hmr/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 # `fastmcp` pins `mcp<2`, so depending on it unconditionally would rule out mcp 2.x forever
 [project.optional-dependencies]
 fastmcp = ["fastmcp>=2.12,<4"]
-mcp = ["mcp>=2,<3"]
+mcp = ["mcp>=1,<3"]
 
 [tool.pdm.version]
 source = "file"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ dependencies = [
 [tool.uv.workspace]
 members = ["examples/*", "packages/*"]
 
+# fastmcp 2.x declares `mcp>=1.24.0` with no upper bound, so uv happily resolves mcp 2.x — a combination it cannot run on
+[tool.uv]
+constraint-dependencies = ["mcp<2"]
+
 [tool.uv.sources]
 uvicorn-hmr = { workspace = true }
 fastapi-reloader = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,6 @@ dependencies = [
 [tool.uv.workspace]
 members = ["examples/*", "packages/*"]
 
-# fastmcp 2.x declares `mcp>=1.24.0` with no upper bound, so uv happily resolves mcp 2.x — a combination it cannot run on
-[tool.uv]
-constraint-dependencies = ["mcp<2"]
-
 [tool.uv.sources]
 uvicorn-hmr = { workspace = true }
 fastapi-reloader = { workspace = true }


### PR DESCRIPTION
Resolves #126

`mcp` 2.x removed `FastMCP` along with mounting and proxying, so the single FastMCP-proxy strategy no longer covers the ecosystem. Since `mcp` 1.x and 2.x are the same distribution and cannot coexist, `pick_backend()` detects which one is installed and returns one of two backends, each a `(base_app, mount, notify)` triple:

| | swap seam | notify seam |
| --- | --- | --- |
| `proxy_backend` — mcp 1.x, FastMCP v2 & v3 | proxy mounted on a stable outer `FastMCP` | `ServerSession` `WeakSet`, as before |
| `swap_backend` — mcp 2.x | the target's manager registries, swapped into a stable outer `MCPServer` | an owned `InMemorySubscriptionBus` |

`fastmcp` therefore moves from a hard dependency to the `[fastmcp]` extra, alongside a new `[mcp]` extra — depending on it unconditionally would rule out `mcp` 2.x forever, since it pins `mcp<2`.

### Verified

Each environment: connect a client, edit the target's tool mid-session, assert the tool list changed **and** that calls route to the new code.

- [x] `fastmcp` 2.14.7 + `mcp` 1.29.0
- [x] `fastmcp` 3.4.5 + `mcp` 1.29.0 — fastmcp 3 replaced `_mounted_servers` with a `providers` list and split `create_proxy` out of `FastMCP.as_proxy`
- [x] SDK v1 `mcp.server.fastmcp.FastMCP` target
- [x] `mcp` 2.0.0 + `MCPServer` target, one client held across the reload

> [!NOTE]
> Known limits of the `mcp` 2.x backend, documented in the README: it talks Python rather than MCP, so targets must be `MCPServer` instances; only the tool/resource/prompt registries are swapped, so `lifespan`, auth, extensions and custom routes stay the outer server's; notifications reach only clients that opened a `subscriptions/listen` stream; and `MCPServer`'s runners take no middleware, so HTTP transport gets no CORS there.